### PR TITLE
Add the ability to return headers for certain Bloomreach errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "bloomreach-transactional-email",
             "version": "1.0.6",
             "license": "SEE LICENSE IN LICENSE",
+            "dependencies": {
+                "http-status-codes": "^2.3.0"
+            },
             "devDependencies": {
                 "@babel/preset-env": "^7.24.3",
                 "@babel/preset-typescript": "^7.24.1",
@@ -6966,6 +6969,12 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
+        },
+        "node_modules/http-status-codes": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+            "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+            "license": "MIT"
         },
         "node_modules/human-signals": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
         "axios": "^1.6.8"
     },
     "main": "dist/index.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "dependencies": {
+        "http-status-codes": "^2.3.0"
+    }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,14 +1,14 @@
 import { AxiosError, RawAxiosResponseHeaders, AxiosHeaders } from 'axios';
 
 export class BloomreachError extends AxiosError {
-    private readonly _message: string
+    private readonly _message: string;
 
     constructor(error: AxiosError) {
         super(error.message, error.code, error.config, error.request, error.response);
         const statusCode = error.response?.status;
         const statusText = error.response?.statusText;
         const response = error.response?.data ?? error.message;
-        this._message = `${statusCode} - ${statusText} - ${JSON.stringify(response, null, 2)}`
+        this._message = `${statusCode} - ${statusText} - ${JSON.stringify(response, null, 2)}`;
     }
 
     getStatus() {
@@ -27,9 +27,9 @@ export class BloomreachError extends AxiosError {
         return this.response?.headers;
     }
 
-    // Expose the old message that was build for these errors.
+    // Expose the old message that was built for these errors.
     getCombinedMessage() {
-        return this._message
+        return this._message;
     }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -50,7 +50,7 @@ export class BloomreachSuppressionList extends BloomreachBadRequest {
     }
 }
 
-export class BloomReachRateLimited extends  BloomreachError {
+export class BloomReachRateLimited extends BloomreachError {
     constructor(status: number, statusText: string, response: any, headers?: RawAxiosResponseHeaders | AxiosResponseHeaders) {
         super(status, statusText, response, headers);
     }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,14 +1,18 @@
-export class BloomreachError extends Error {
-    private _status: number;
-    private _statusText: string;
-    private _response: any;
+import { AxiosResponseHeaders, RawAxiosResponseHeaders } from "axios";
 
-    constructor(status: number, statusText: string, response: any) {
+export class BloomreachError extends Error {
+    private readonly _status: number;
+    private readonly _statusText: string;
+    private readonly _response: any;
+    private readonly _headers: any;
+
+    constructor(status: number, statusText: string, response: any, headers?: RawAxiosResponseHeaders | AxiosResponseHeaders) {
         super(`${status} - ${statusText} - ${JSON.stringify(response, null, 2)}`);
 
         this._status = status;
         this._statusText = statusText;
         this._response = response;
+        this._headers = headers
     }
 
     getStatus() {
@@ -21,6 +25,10 @@ export class BloomreachError extends Error {
 
     getResponse() {
         return this._response;
+    }
+
+    getHeaders() {
+        return this._headers;
     }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { AxiosResponseHeaders, RawAxiosResponseHeaders } from "axios";
+import { AxiosResponseHeaders, RawAxiosResponseHeaders } from 'axios';
 
 export class BloomreachError extends Error {
     private readonly _status: number;
@@ -12,7 +12,7 @@ export class BloomreachError extends Error {
         this._status = status;
         this._statusText = statusText;
         this._response = response;
-        this._headers = headers
+        this._headers = headers;
     }
 
     getStatus() {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -49,3 +49,9 @@ export class BloomreachSuppressionList extends BloomreachBadRequest {
         super(status, statusText, response);
     }
 }
+
+export class BloomReachRateLimited extends  BloomreachError {
+    constructor(status: number, statusText: string, response: any, headers?: RawAxiosResponseHeaders | AxiosResponseHeaders) {
+        super(status, statusText, response, headers);
+    }
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,57 +1,58 @@
-import { AxiosResponseHeaders, RawAxiosResponseHeaders } from 'axios';
+import { AxiosError, RawAxiosResponseHeaders, AxiosHeaders } from 'axios';
 
-export class BloomreachError extends Error {
-    private readonly _status: number;
-    private readonly _statusText: string;
-    private readonly _response: any;
-    private readonly _headers: any;
+export class BloomreachError extends AxiosError {
+    private readonly _message: string
 
-    constructor(status: number, statusText: string, response: any, headers?: RawAxiosResponseHeaders | AxiosResponseHeaders) {
-        super(`${status} - ${statusText} - ${JSON.stringify(response, null, 2)}`);
-
-        this._status = status;
-        this._statusText = statusText;
-        this._response = response;
-        this._headers = headers;
+    constructor(error: AxiosError) {
+        super(error.message, error.code, error.config, error.request, error.response);
+        const statusCode = error.response?.status;
+        const statusText = error.response?.statusText;
+        const response = error.response?.data ?? error.message;
+        this._message = `${statusCode} - ${statusText} - ${JSON.stringify(response, null, 2)}`
     }
 
     getStatus() {
-        return this._status;
+        return this.response?.status;
     }
 
     getStatusText() {
-        return this._statusText;
+        return this.response?.statusText;
     }
 
     getResponse() {
-        return this._response;
+        return this.response?.data ?? this.message;
     }
 
-    getHeaders() {
-        return this._headers;
+    getHeaders(): RawAxiosResponseHeaders | (RawAxiosResponseHeaders & AxiosHeaders) | undefined {
+        return this.response?.headers;
+    }
+
+    // Expose the old message that was build for these errors.
+    getCombinedMessage() {
+        return this._message
     }
 }
 
 export class BloomreachBadRequest extends BloomreachError {
-    constructor(status: number, statusText: string, response: any) {
-        super(status, statusText, response);
+    constructor(error: AxiosError) {
+        super(error);
     }
 }
 
 export class BloomreachTemplateNotFound extends BloomreachBadRequest {
-    constructor(status: number, statusText: string, response: any) {
-        super(status, statusText, response);
+    constructor(error: AxiosError) {
+        super(error);
     }
 }
 
 export class BloomreachSuppressionList extends BloomreachBadRequest {
-    constructor(status: number, statusText: string, response: any) {
-        super(status, statusText, response);
+    constructor(error: AxiosError) {
+        super(error);
     }
 }
 
 export class BloomReachRateLimited extends BloomreachError {
-    constructor(status: number, statusText: string, response: any, headers: RawAxiosResponseHeaders | AxiosResponseHeaders) {
-        super(status, statusText, response, headers);
+    constructor(error: AxiosError) {
+        super(error);
     }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -51,7 +51,7 @@ export class BloomreachSuppressionList extends BloomreachBadRequest {
 }
 
 export class BloomReachRateLimited extends BloomreachError {
-    constructor(status: number, statusText: string, response: any, headers?: RawAxiosResponseHeaders | AxiosResponseHeaders) {
+    constructor(status: number, statusText: string, response: any, headers: RawAxiosResponseHeaders | AxiosResponseHeaders) {
         super(status, statusText, response, headers);
     }
 }

--- a/src/send-email.ts
+++ b/src/send-email.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { BloomreachBadRequest, BloomreachError, BloomreachSuppressionList, BloomreachTemplateNotFound } from './lib/errors';
+import { BloomreachBadRequest, BloomreachError, BloomReachRateLimited, BloomreachSuppressionList, BloomreachTemplateNotFound } from './lib/errors';
 
 export interface Auth {
     username: string;
@@ -144,6 +144,10 @@ export const sendEmail = async (
                 throw new BloomreachSuppressionList(statusCode, statusText, response);
             }
             throw new BloomreachBadRequest(statusCode, statusText, response);
+        }
+
+        if (statusCode === 429) {
+            throw new BloomReachRateLimited(statusCode, statusText, response, headers);
         }
 
         throw new BloomreachError(statusCode, statusText, response, headers);

--- a/src/send-email.ts
+++ b/src/send-email.ts
@@ -151,13 +151,11 @@ export const sendEmail = async (
 
         // Bloomreach can wrap downstream errors. We identify underlying 429
         // errors to help with retry logic.
-        if ((statusCode === StatusCodes.BAD_GATEWAY) && (
-          Array.isArray(response?.errors) &&
-          response?.errors?.find(
-            (mes: string) =>
-              mes.toLocaleLowerCase().includes('429 Too Many Requests')
-          )
-        )) {
+        if (
+            statusCode === StatusCodes.BAD_GATEWAY &&
+            Array.isArray(response?.errors) &&
+            response?.errors?.find((mes: string) => mes.toLocaleLowerCase().includes('429 Too Many Requests'))
+        ) {
             throw new BloomReachRateLimited(error);
         }
 

--- a/src/send-email.ts
+++ b/src/send-email.ts
@@ -124,6 +124,7 @@ export const sendEmail = async (
         const statusCode = error.response?.status;
         const statusText = error.response?.statusText;
         const response = error.response?.data ?? error.message;
+        const headers = error.response?.headers;
 
         if (statusCode === 400) {
             if (
@@ -145,7 +146,7 @@ export const sendEmail = async (
             throw new BloomreachBadRequest(statusCode, statusText, response);
         }
 
-        throw new BloomreachError(statusCode, statusText, response);
+        throw new BloomreachError(statusCode, statusText, response, headers);
     }
 };
 

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -87,7 +87,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachError);
-                expect(error.message).toEqual('500 - null - "error!"');
+                expect(error.getCombinedMessage()).toEqual('500 - null - "error!"');
             }
         });
 
@@ -107,7 +107,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachBadRequest);
-                expect(error.message).toEqual('400 - null - "error!"');
+                expect(error.getCombinedMessage()).toEqual('400 - null - "error!"');
             }
         });
 
@@ -133,7 +133,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachTemplateNotFound);
-                expect(error.message).toEqual(
+                expect(error.getCombinedMessage()).toEqual(
                     `400 - null - ${JSON.stringify(
                         {
                             errors: {
@@ -171,7 +171,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachTemplateNotFound);
-                expect(error.message).toEqual(
+                expect(error.getCombinedMessage()).toEqual(
                     `400 - null - ${JSON.stringify(
                         {
                             errors: {
@@ -207,7 +207,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachSuppressionList);
-                expect(error.message).toEqual(
+                expect(error.getCombinedMessage()).toEqual(
                     `400 - null - ${JSON.stringify(
                         {
                             errors: ['Email address or domain is on the suppression list'],
@@ -239,7 +239,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachSuppressionList);
-                expect(error.message).toEqual(
+                expect(error.getCombinedMessage()).toEqual(
                     `400 - null - ${JSON.stringify(
                         {
                             errors: ['Email address or domain is in the suppression list'],
@@ -273,7 +273,7 @@ describe('error handling', () => {
                 await sendEmail(auth, campaignName, customerId, emailContent);
             } catch (error: any) {
                 expect(error).toBeInstanceOf(BloomreachBadRequest);
-                expect(error.message).toEqual(
+                expect(error.getCombinedMessage()).toEqual(
                     `400 - null - ${JSON.stringify(
                         {
                             errors: {

--- a/test/lib/bloomreach-error.test.ts
+++ b/test/lib/bloomreach-error.test.ts
@@ -1,4 +1,4 @@
-import { BloomreachError } from '../../src/lib/errors';
+import { BloomreachError } from '../../src';
 
 describe('bloomreach error', () => {
     const statusCode = 500;
@@ -23,5 +23,19 @@ describe('bloomreach error', () => {
     it('error message should include all elements', () => {
         const error = new BloomreachError(statusCode, statusText, response);
         expect(error.message).toEqual(`500 - statusText - ${JSON.stringify(response, null, 2)}`);
+    });
+
+    it('should get headers', () => {
+        const headers = {
+            'content-type': 'text/html',
+            'x-random-header': 'set',
+        };
+        const error = new BloomreachError(statusCode, statusText, response, headers);
+        expect(error.getHeaders()).toEqual(headers);
+    });
+
+    it('should handle no headers being set', () => {
+        const error = new BloomreachError(statusCode, statusText, response);
+        expect(error.getHeaders()).toBeUndefined();
     });
 });

--- a/test/lib/bloomreach-error.test.ts
+++ b/test/lib/bloomreach-error.test.ts
@@ -1,41 +1,42 @@
 import { BloomreachError } from '../../src';
+import { AxiosError, AxiosResponse } from "axios";
 
 describe('bloomreach error', () => {
-    const statusCode = 500;
-    const statusText = 'statusText';
-    const response = { key: 'value' };
+    const response: AxiosResponse = {
+        data: { key: 'value' },
+        status: 500,
+        statusText: 'statusText',
+        headers: {
+            'content-type': 'text/html',
+            'x-random-header': 'set',
+        },
+        config: undefined
+    }
+
+    const axiosError = new AxiosError('axiosError', undefined, undefined, undefined, response)
 
     it('should get status code', () => {
-        const error = new BloomreachError(statusCode, statusText, response);
-        expect(error.getStatus()).toEqual(statusCode);
+        const error = new BloomreachError(axiosError);
+        expect(error.getStatus()).toEqual(response.status);
     });
 
     it('should get status text', () => {
-        const error = new BloomreachError(statusCode, statusText, response);
-        expect(error.getStatusText()).toEqual(statusText);
+        const error = new BloomreachError(axiosError);
+        expect(error.getStatusText()).toEqual(response.statusText);
     });
 
     it('should get response', () => {
-        const error = new BloomreachError(statusCode, statusText, response);
-        expect(error.getResponse()).toEqual(response);
+        const error = new BloomreachError(axiosError);
+        expect(error.getResponse()).toEqual(response.data);
     });
 
-    it('error message should include all elements', () => {
-        const error = new BloomreachError(statusCode, statusText, response);
-        expect(error.message).toEqual(`500 - statusText - ${JSON.stringify(response, null, 2)}`);
+    it('should build a combined message including all relevant elements', () => {
+        const error = new BloomreachError(axiosError);
+        expect(error.getCombinedMessage()).toEqual(`500 - statusText - ${JSON.stringify(response.data, null, 2)}`);
     });
 
     it('should get headers', () => {
-        const headers = {
-            'content-type': 'text/html',
-            'x-random-header': 'set',
-        };
-        const error = new BloomreachError(statusCode, statusText, response, headers);
-        expect(error.getHeaders()).toEqual(headers);
-    });
-
-    it('should handle no headers being set', () => {
-        const error = new BloomreachError(statusCode, statusText, response);
-        expect(error.getHeaders()).toBeUndefined();
+        const error = new BloomreachError(axiosError);
+        expect(error.getHeaders()).toEqual(response.headers);
     });
 });

--- a/test/lib/bloomreach-error.test.ts
+++ b/test/lib/bloomreach-error.test.ts
@@ -1,5 +1,5 @@
 import { BloomreachError } from '../../src';
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse } from 'axios';
 
 describe('bloomreach error', () => {
     const response: AxiosResponse = {
@@ -10,10 +10,10 @@ describe('bloomreach error', () => {
             'content-type': 'text/html',
             'x-random-header': 'set',
         },
-        config: undefined
-    }
+        config: undefined,
+    };
 
-    const axiosError = new AxiosError('axiosError', undefined, undefined, undefined, response)
+    const axiosError = new AxiosError('axiosError', undefined, undefined, undefined, response);
 
     it('should get status code', () => {
         const error = new BloomreachError(axiosError);


### PR DESCRIPTION
Changes:

  * Headers can now optionally be set on a BloomreachError type
  * Tests have been introduced for the headers in the BloomreachError type
  * A new BloomreachRateLimit type is introduced that accepts (and requires) headers
  * When sending email a BloomreachRateLimit will be returned if a 429 is received 
  * Tests for this have been added
  * Fix typos and warnings in the files edited
